### PR TITLE
Avoid UB when drawing random uniform ints

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 # Disable runtime-references, it's not in the Google style guide anymore
 # and is less error prone. See .clang-tidy
-filter=-build/c++11,+build/c++17,-build/include_subdir,-runtime/references
+filter=-build/c++11,+build/c++17,-build/include_subdir,-runtime/references,-readability/nolint

--- a/envpool/sokoban/BUILD
+++ b/envpool/sokoban/BUILD
@@ -42,6 +42,7 @@ cc_library(
         "//envpool/core:async_envpool",
         "//envpool/core:env",
         "//envpool/core:env_spec",
+        "//envpool/utils:safe_random_h",
     ],
 )
 

--- a/envpool/sokoban/level_loader.cc
+++ b/envpool/sokoban/level_loader.cc
@@ -14,6 +14,8 @@
 
 #include "level_loader.h"
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
@@ -22,6 +24,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+
+#include "envpool/utils/safe_random.h"
 
 namespace sokoban {
 
@@ -90,7 +94,8 @@ void PrintLevel(std::ostream& os, const SokobanLevel& vec) {
 }
 
 void LevelLoader::LoadNewFile(std::mt19937& gen) {
-  std::uniform_int_distribution<size_t> load_file_idx_r(
+  CHECK_GE(level_file_paths_.size(), static_cast<size_t>(1));
+  auto load_file_idx_r = envpool::SafeUniformIntDistribution<size_t>(
       0, level_file_paths_.size() - 1);
   const size_t load_file_idx = load_file_idx_r(gen);
   const std::filesystem::path& file_path = level_file_paths_.at(load_file_idx);

--- a/envpool/sokoban/sokoban_envpool.cc
+++ b/envpool/sokoban/sokoban_envpool.cc
@@ -20,14 +20,15 @@
 #include <vector>
 
 #include "envpool/core/py_envpool.h"
+#include "envpool/utils/safe_random.h"
 
 namespace sokoban {
 
 void SokobanEnv::Reset() {
   const int max_episode_steps = spec_.config["max_episode_steps"_];
   const int min_episode_steps = spec_.config["min_episode_steps"_];
-  std::uniform_int_distribution<int> episode_length_rand(min_episode_steps,
-                                                         max_episode_steps);
+  auto episode_length_rand = envpool::SafeUniformIntDistribution<int>(
+      min_episode_steps, max_episode_steps);
   current_max_episode_steps_ = episode_length_rand(gen_);
 
   world_ = *(level_loader_.RandomLevel(gen_));

--- a/envpool/utils/BUILD
+++ b/envpool/utils/BUILD
@@ -31,3 +31,8 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "safe_random_h",
+    hdrs = ["safe_random.h"],
+)

--- a/envpool/utils/CPPLINT.cfg
+++ b/envpool/utils/CPPLINT.cfg
@@ -1,0 +1,2 @@
+# Allow C int types in this directory
+filter=-runtime/int

--- a/envpool/utils/safe_random.h
+++ b/envpool/utils/safe_random.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023-2024 FAR AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ENVPOOL_UTILS_SAFE_RANDOM_H_
+#define ENVPOOL_UTILS_SAFE_RANDOM_H_
+
+#include <glog/logging.h>
+
+#include <random>
+#include <type_traits>
+
+namespace envpool {
+
+template <typename IntType>
+std::uniform_int_distribution<IntType> SafeUniformIntDistribution(IntType a,
+                                                                  IntType b) {
+  // Prevent UB from a > b.
+  // https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution/operator()
+  CHECK_LE(a, b);
+  // Prevent UB from IntType not being one of the blessed ones.
+  // https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
+  static_assert(
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, short> ||
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, int> ||
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, long> ||
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, long long> ||
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, unsigned short> ||
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, unsigned int> ||
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, unsigned long> ||
+      // NOLINTNEXTLINE(google-runtime-int)
+      std::is_same_v<IntType, unsigned long long>);
+
+  return std::uniform_int_distribution<IntType>(a, b);
+}
+}  // namespace envpool
+
+#endif  // ENVPOOL_UTILS_SAFE_RANDOM_H_


### PR DESCRIPTION
I resent the large amount of NOLINT needed (and linter config changes) but oh well.