### PR TITLE
Upgrade pytorch and cuda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
   docker_img_version:
     # Docker image version for running tests.
     type: string
-    default: "8f41d1e-envpool-ci"
+    default: "8d8cf1a-envpool-ci"
 
 workflows:
   test-jobs:

--- a/envpool/classic_control/pendulum.h
+++ b/envpool/classic_control/pendulum.h
@@ -77,8 +77,9 @@ class PendulumEnv : public Env<PendulumEnvSpec> {
   void Step(const Action& action) override {
     done_ = (++elapsed_step_ >= max_episode_steps_);
     float act = action["action"_];
-    double u =
-        act < -kMaxTorque ? -kMaxTorque : act > kMaxTorque ? kMaxTorque : act;
+    double u = act < -kMaxTorque  ? -kMaxTorque
+               : act > kMaxTorque ? kMaxTorque
+                                  : act;
     double cost =
         theta_ * theta_ + 0.1 * theta_dot_ * theta_dot_ + 0.001 * u * u;
     double new_theta_dot =
@@ -86,9 +87,9 @@ class PendulumEnv : public Env<PendulumEnvSpec> {
     if (version_ == 0) {
       theta_ += new_theta_dot * kDt;
     }
-    theta_dot_ = new_theta_dot < -kMaxSpeed
-                     ? -kMaxSpeed
-                     : new_theta_dot > kMaxSpeed ? kMaxSpeed : new_theta_dot;
+    theta_dot_ = new_theta_dot < -kMaxSpeed  ? -kMaxSpeed
+                 : new_theta_dot > kMaxSpeed ? kMaxSpeed
+                                             : new_theta_dot;
     if (version_ == 1) {
       theta_ += new_theta_dot * kDt;
     }

--- a/envpool/core/env_spec.h
+++ b/envpool/core/env_spec.h
@@ -52,8 +52,8 @@ class EnvSpec {
   using Config = decltype(ConcatDict(common_config, EnvFns::DefaultConfig()));
   using ConfigKeys = typename Config::Keys;
   using ConfigValues = typename Config::Values;
-  using StateSpec = decltype(
-      ConcatDict(common_state_spec, EnvFns::StateSpec(std::declval<Config>())));
+  using StateSpec = decltype(ConcatDict(
+      common_state_spec, EnvFns::StateSpec(std::declval<Config>())));
   using ActionSpec = decltype(ConcatDict(
       common_action_spec, EnvFns::ActionSpec(std::declval<Config>())));
   using StateKeys = typename StateSpec::Keys;

--- a/envpool/sokoban/level_loader.cc
+++ b/envpool/sokoban/level_loader.cc
@@ -32,10 +32,7 @@ LevelLoader::LevelLoader(const std::filesystem::path& base_path,
                          int verbose)
     : load_sequentially_(load_sequentially),
       n_levels_to_load_(n_levels_to_load),
-      levels_loaded_(0),
-      levels_(0),
       cur_level_(levels_.begin()),
-      level_file_paths_(0),
       verbose(verbose) {
   if (std::filesystem::is_regular_file(base_path)) {
     level_file_paths_.push_back(base_path);

--- a/envpool/sokoban/level_loader.h
+++ b/envpool/sokoban/level_loader.h
@@ -38,10 +38,10 @@ class LevelLoader {
  protected:
   bool load_sequentially_;
   int n_levels_to_load_;
-  int levels_loaded_;
-  std::vector<SokobanLevel> levels_;
+  int levels_loaded_{0};
+  std::vector<SokobanLevel> levels_{0};
   std::vector<SokobanLevel>::iterator cur_level_;
-  std::vector<std::filesystem::path> level_file_paths_;
+  std::vector<std::filesystem::path> level_file_paths_{0};
   std::vector<std::filesystem::path>::iterator cur_file_;
   void LoadFile(std::mt19937& gen);
 


### PR DESCRIPTION
- Update to image with Pytorch 2.2.1
- LLVM changed version 10->14, so make `clang-format` and `clang-tidy` new versions happy.